### PR TITLE
Adding optional flags to show the full file paths in sourceLocation->file

### DIFF
--- a/afterburner/logging.py
+++ b/afterburner/logging.py
@@ -143,6 +143,7 @@ class _BufferedStreamHandler(logging.StreamHandler):
             # "requestMethod": method,
             "status": status_code,
         }
+        root_app_dir_length = len(root_app_dir) if root_app_dir else 0
         for record in records:
             message = self.formatter.format(record)
             # Output the timestamp of the record, so it shows up in the correct


### PR DESCRIPTION
I found it useful to include full file paths as the sourceLocation->file field of each log entry (instead of just the filename).

Happy for you to include / change and merge if you think it's useful (and if not, no offense taken).

NOTES: 

- I just copy and pasted from my local code into GitHub's code editor without testing to see if the changes I've made to your repo work properly (but they should).
- I haven't made any unit tests for this change, sorry (I've tested locally and it works fine for me though).